### PR TITLE
Improvements on docker run process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_script:
   - if [ $TRAVIS_PHP_VERSION != "7" ]; then echo "extension = mongo.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi;
   - if [ $TRAVIS_PHP_VERSION == "7" ]; then echo "extension = mongodb.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi;
   - composer self-update
-  - composer update --prefer-dist $DEPENDENCIES
+  - composer update --prefer-source $DEPENDENCIES
   - if [ $TRAVIS_PHP_VERSION == "7" ]; then composer require alcaeus/mongo-php-adapter ^1.0; fi;
   - psql -c 'create database event_store_adapter_benchmarks;' -U postgres
   - mysql -e 'create database event_store_adapter_benchmarks;'

--- a/README.md
+++ b/README.md
@@ -37,27 +37,27 @@ by one of the following commands. PHP 7 is used, but you are free to change the
 `docker run --rm -it --volume $(pwd):/app prooph/composer:7.0 require alcaeus/mongo-php-adapter`.
 
 ```
-$ export COMPOSE_FILE=docker-compose.yml:docker-compose-mongodb.yml && docker-compose up -d && docker-compose logs -f php && docker-compose down
+$ (export COMPOSE_FILE=docker-compose.yml:docker-compose-mongodb.yml; docker-compose run php && docker-compose down)
 ```
 
 ### For MariaDB (MySQL)
 ```
-$ export COMPOSE_FILE=docker-compose.yml:docker-compose-mariadb.yml && docker-compose up -d && docker-compose logs -f php && docker-compose down
+$ (export COMPOSE_FILE=docker-compose.yml:docker-compose-mariadb.yml; docker-compose run php && docker-compose down)
 ```
 
 ### For MySQL
 ```
-$ export COMPOSE_FILE=docker-compose.yml:docker-compose-mysql.yml && docker-compose up -d && docker-compose logs -f php && docker-compose down
+$ (export COMPOSE_FILE=docker-compose.yml:docker-compose-mysql.yml; docker-compose run php && docker-compose down)
 ```
 
 ### For Percona (MySQL)
 ```
-$ export COMPOSE_FILE=docker-compose.yml:docker-compose-percona.yml && docker-compose up -d && docker-compose logs -f php && docker-compose down
+$ (export COMPOSE_FILE=docker-compose.yml:docker-compose-percona.yml; docker-compose run php && docker-compose down)
 ```
 
 ### For PostgreSQL
 ```
-$ export COMPOSE_FILE=docker-compose.yml:docker-compose-postgresql.yml && docker-compose up -d && docker-compose logs -f php && docker-compose down
+$ (export COMPOSE_FILE=docker-compose.yml:docker-compose-postgresql.yml; docker-compose run php && docker-compose down)
 ```
 
 ## Support

--- a/docker-compose-mariadb.yml
+++ b/docker-compose-mariadb.yml
@@ -1,6 +1,8 @@
 version: '2'
 services:
   php:
+    depends_on:
+      - mariadb
     environment:
       - MYSQL_HOST=mariadb
       - MYSQL_ROOT_PASSWORD=dev

--- a/docker-compose-mariadb.yml
+++ b/docker-compose-mariadb.yml
@@ -10,8 +10,6 @@ services:
 
   mariadb:
     image: mariadb
-    ports:
-      - 3306:3306
     environment:
       - MYSQL_ROOT_PASSWORD=dev
       - MYSQL_USER=dev

--- a/docker-compose-mongodb.yml
+++ b/docker-compose-mongodb.yml
@@ -1,6 +1,8 @@
 version: '2'
 services:
   php:
+    depends_on:
+      - mongodb
     environment:
       - MONGODB_HOST=mongodb
       - BENCHMARK_CASE=mongodb

--- a/docker-compose-mongodb.yml
+++ b/docker-compose-mongodb.yml
@@ -9,5 +9,3 @@ services:
 
   mongodb:
       image: mongo
-      ports:
-        - 27017:27017

--- a/docker-compose-mysql.yml
+++ b/docker-compose-mysql.yml
@@ -10,8 +10,6 @@ services:
 
   mysql:
     image: mysql
-    ports:
-      - 3306:3306
     environment:
       - MYSQL_ROOT_PASSWORD=dev
       - MYSQL_USER=dev

--- a/docker-compose-mysql.yml
+++ b/docker-compose-mysql.yml
@@ -1,6 +1,8 @@
 version: '2'
 services:
   php:
+    depends_on:
+      - mysql
     environment:
       - MYSQL_HOST=mysql
       - MYSQL_ROOT_PASSWORD=dev

--- a/docker-compose-percona.yml
+++ b/docker-compose-percona.yml
@@ -10,8 +10,6 @@ services:
 
   percona:
     image: percona
-    ports:
-      - 3306:3306
     environment:
       - MYSQL_ROOT_PASSWORD=dev
       - MYSQL_USER=dev

--- a/docker-compose-percona.yml
+++ b/docker-compose-percona.yml
@@ -1,6 +1,8 @@
 version: '2'
 services:
   php:
+    depends_on:
+      - percona
     environment:
       - MYSQL_HOST=percona
       - MYSQL_ROOT_PASSWORD=dev

--- a/docker-compose-postgresql.yml
+++ b/docker-compose-postgresql.yml
@@ -10,8 +10,6 @@ services:
 
   postgres:
     image: postgres
-    ports:
-      - 5432:5432
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=dev

--- a/docker-compose-postgresql.yml
+++ b/docker-compose-postgresql.yml
@@ -1,6 +1,8 @@
 version: '2'
 services:
   php:
+    depends_on:
+      - postgres
     environment:
       - POSTGRES_HOST=postgres
       - POSTGRES_PASSWORD=dev


### PR DESCRIPTION
This PR tends to improves the way to run benchmarks with docker by:

- adding brackets around readme terminal command examples to prevent global population of COMPOSE_FILE environment var
- removing the ```up -d && logs -f``` workaround by ```docker-compose run``` with depends_on config value for docker-compose.yml files
- removing port population to docker host


/cc @sandrokeil  